### PR TITLE
Fix #2 - isEqual not working when a differing value is found as 0

### DIFF
--- a/src/isEqual.ts
+++ b/src/isEqual.ts
@@ -25,13 +25,16 @@ export function isEqual(a: EqualityType, b: EqualityType): boolean {
     if (Array.isArray(a)) {
       return (
         a.length === (b as IndividualEqualityType[]).length &&
-        !a.find((value, index) => !isEqual(value, (b as IndividualEqualityType[])[index]))
+        isNullOrUndefined(a.find((value, index) => !isEqual(value, (b as IndividualEqualityType[])[index])))
       );
     } else if (typeof a === 'object') {
       const keysA = Object.keys(a as object).sort();
       const keysB = Object.keys(b as object).sort();
 
-      if (isEqual(keysA, keysB) && !Object.entries(a as object).find(([key, value]) => !isEqual((b as object)[key], value))) {
+      if (
+        isEqual(keysA, keysB) &&
+        isNullOrUndefined(Object.entries(a as object).find(([key, value]) => !isEqual((b as object)[key], value)))
+      ) {
         return true;
       }
     }

--- a/tests/isEqual.spec.ts
+++ b/tests/isEqual.spec.ts
@@ -178,6 +178,13 @@ describe('isEqual', () => {
 
       expect(isEqual(a, b)).toBe(false);
     });
+
+    it('differing number arrays are not equal', () => {
+      const a = [23, 0];
+      const b = [23, 61];
+
+      expect(isEqual(a, b)).toBe(false);
+    });
   });
 
   describe('objects', () => {


### PR DESCRIPTION
Fix isEqual returning true when it finds a value that is different and the value is truthy.

Resolves #2 